### PR TITLE
Add browser compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # postguard-docs
+
+Documentation site for [PostGuard](https://postguard.eu), an identity-based encryption system. Built with [VitePress](https://vitepress.dev).
+
+## Browser Compatibility
+
+The PostGuard SDK (`@e4a/pg-js`) uses WebAssembly and top-level `await`. It requires a modern browser that supports both features:
+
+- Chrome / Edge 89+
+- Firefox 89+
+- Safari 15+
+
+Node.js 18+ is supported for server-side use. No polyfills are needed in any environment.
+
+## Development
+
+```bash
+npm install
+npm run docs:dev
+```


### PR DESCRIPTION
## Summary

- Adds a Browser Compatibility section to `README.md` listing minimum browser versions required by the PostGuard SDK (`@e4a/pg-js`): Chrome/Edge 89+, Firefox 89+, Safari 15+
- Notes Node.js 18+ support and that no polyfills are needed
- Adds a brief project description and development instructions to the previously bare README

Closes #2

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm browser version numbers are accurate (based on WebAssembly + top-level await support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)