### PR TITLE
docs: align JS + .NET notify API with silent-by-default redesign

### DIFF
--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -153,7 +153,7 @@ const sealed = pg.encrypt({
 });
 ```
 
-<small>[Source: encryption.ts#L26-L35](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts#L26-L35)</small>
+<small>[Source: encryption.ts#L27-L33](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts#L27-L33)</small>
 
 You can require extra attributes beyond email using `.extraAttribute()`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,9 +54,11 @@ const sealed = pg.encrypt({
   sign: pg.sign.apiKey('PG-your-key')
 });
 
-await sealed.upload({ notify: { message: 'Here are your files' } });
+await sealed.upload({
+  notify: { recipients: true, message: 'Here are your files' }
+});
 ```
 
-<small>[Source: encryption.ts#L22-L46](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts#L22-L46)</small>
+<small>[Source: encryption.ts#L24-L44](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts#L24-L44)</small>
 
 Read the [concepts guide](/guide/concepts) to understand how this works, or jump straight to [getting started](/sdk/getting-started).

--- a/docs/repos/pg-dotnet.md
+++ b/docs/repos/pg-dotnet.md
@@ -67,12 +67,20 @@ var sealed = pg.Encrypt(new EncryptInput
     Sign = pg.Sign.ApiKey(apiKey)
 });
 
-// Upload only: returns UUID for custom delivery
+// Silent upload — no Cryptify-sent emails. Returns UUID for custom delivery.
 var result = await sealed.UploadAsync();
 
-// Or upload + send email notification
+// Or upload + opt into Cryptify-sent emails. Recipients = true emails each
+// recipient with a download link; Sender = true adds a confirmation back
+// to the sender. Both default false.
 var result = await sealed.UploadAsync(new UploadOptions
 {
-    Notify = new NotifyOptions { Message = "Your documents", Language = "EN" }
+    Notify = new NotifyOptions
+    {
+        Recipients = true,
+        Sender = true,
+        Message = "Your documents",
+        Language = "EN"
+    }
 });
 ```

--- a/docs/repos/pg-sveltekit.md
+++ b/docs/repos/pg-sveltekit.md
@@ -31,7 +31,7 @@ export default defineConfig({
 });
 ```
 
-<small>[Source: vite.config.ts](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/vite.config.ts)</small>
+<small>[Source: vite.config.ts](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/vite.config.ts)</small>
 
 No Node.js polyfills are needed. The SDK handles browser compatibility internally.
 
@@ -47,7 +47,7 @@ PUBLIC_APP_NAME=PostGuard for Business Example
 PG_API_KEY=PG-your-key-here
 ```
 
-<small>[Source: .env.example](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/.env.example)</small>
+<small>[Source: .env.example](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/.env.example)</small>
 
 ```ts
 import { env } from '$env/dynamic/private';
@@ -55,7 +55,7 @@ import { env } from '$env/dynamic/private';
 export const PG_API_KEY = env['PG_API_KEY'] ?? '';
 ```
 
-<small>[Source: config.server.ts](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/config.server.ts)</small>
+<small>[Source: config.server.ts](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/config.server.ts)</small>
 
 ```ts
 import { env } from '$env/dynamic/public';
@@ -65,7 +65,7 @@ export const PKG_URL = env.PUBLIC_PKG_URL || 'https://pkg.staging.yivi.app';
 export const CRYPTIFY_URL = env.PUBLIC_CRYPTIFY_URL || 'https://fileshare.staging.yivi.app';
 ```
 
-<small>[Source: config.ts](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/config.ts)</small>
+<small>[Source: config.ts](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/config.ts)</small>
 
 ## Encrypt and Upload Files
 
@@ -96,9 +96,9 @@ export async function encryptAndSend(options: EncryptAndSendOptions): Promise<st
 
   const result = await sealed.upload({
     notify: {
+      recipients: true,
       message: message ?? undefined,
-      language: 'EN',
-      confirmToSender: false
+      language: 'EN'
     }
   });
 
@@ -106,7 +106,7 @@ export async function encryptAndSend(options: EncryptAndSendOptions): Promise<st
 }
 ```
 
-<small>[Source: encryption.ts](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts)</small>
+<small>[Source: encryption.ts](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts)</small>
 
 The server load function passes the API key to the page:
 

--- a/docs/repos/postguard-dotnet.md
+++ b/docs/repos/postguard-dotnet.md
@@ -28,15 +28,17 @@ var sealed = pg.Encrypt(new EncryptInput
     Sign = pg.Sign.ApiKey("PG-xxx")
 });
 
-// Upload only: returns UUID for custom email distribution
+// Silent upload — no Cryptify-sent emails. Returns UUID for custom delivery.
 var result = await sealed.UploadAsync();
 Console.WriteLine(result.Uuid);
 
-// Upload with email notification
+// Or opt into Cryptify-sent emails (both flags default false):
 var result = await sealed.UploadAsync(new UploadOptions
 {
     Notify = new NotifyOptions
     {
+        Recipients = true,
+        Sender = true,
         Message = "Your documents",
         Language = "EN"
     }

--- a/docs/repos/postguard-js.md
+++ b/docs/repos/postguard-js.md
@@ -39,9 +39,9 @@ The SDK uses a lazy builder pattern. `pg.encrypt()` and `pg.open()` return build
 ```ts
 // Encrypt: nothing happens until .upload() or .toBytes()
 const sealed = pg.encrypt({ files, recipients, sign });
-await sealed.upload();                                // encrypt + stream to Cryptify
-await sealed.upload({ notify: { message: 'Hi' } });  // + email notification
-const bytes = await sealed.toBytes();                 // encrypt + buffer in memory
+await sealed.upload();                                       // silent: stream to Cryptify, no emails
+await sealed.upload({ notify: { recipients: true } });       // + email each recipient a link
+const bytes = await sealed.toBytes();                        // encrypt + buffer in memory
 
 // Decrypt: nothing happens until .inspect() or .decrypt()
 const opened = pg.open({ uuid });
@@ -63,12 +63,19 @@ const sealed = pg.encrypt({
   signal: abortController.signal,
 });
 
-// Upload only (returns UUID for custom delivery)
+// Silent upload — no Cryptify-sent emails. Returns UUID for custom delivery.
 const { uuid } = await sealed.upload();
 
-// Upload and have Cryptify send email notifications
+// Or opt into Cryptify-sent emails. `recipients: true` emails each recipient
+// with a download link; `sender: true` adds a confirmation back to the
+// sender. Both default false.
 const { uuid } = await sealed.upload({
-  notify: { message: 'Here are your documents.', language: 'EN' },
+  notify: {
+    recipients: true,
+    sender: false,
+    message: 'Here are your documents.',
+    language: 'EN',
+  },
 });
 ```
 
@@ -82,7 +89,7 @@ const pg = new PostGuard({
 });
 ```
 
-<small>[Source: src/types.ts](https://github.com/encryption4all/postguard-js/blob/33bede4cd1389bc729dca75ad071eb7bf47cd3f1/src/types.ts)</small>
+<small>[Source: src/types.ts](https://github.com/encryption4all/postguard-js/blob/2e2e0442a23b9f821a2bca008fe270af6c487e30/src/types.ts)</small>
 
 ### Encrypt raw data (no upload)
 

--- a/docs/sdk/dotnet-encryption.md
+++ b/docs/sdk/dotnet-encryption.md
@@ -53,27 +53,39 @@ var sealed = pg.Encrypt(new EncryptInput
 
 | Method | Returns | Description |
 |---|---|---|
-| `UploadAsync(ct?)` | `UploadResult` | Encrypt and upload to Cryptify. Returns UUID. |
-| `UploadAsync(options, ct?)` | `UploadResult` | Encrypt, upload, and send email notification. |
+| `UploadAsync(ct?)` | `UploadResult` | Encrypt and upload to Cryptify silently — no Cryptify-sent emails. Returns UUID. |
+| `UploadAsync(options, ct?)` | `UploadResult` | Same, plus opt-in Cryptify-sent emails (see below). |
 | `ToBytesAsync(ct?)` | `byte[]` | Encrypt and return the raw sealed bytes. |
 
 All methods accept an optional `CancellationToken`.
 
 ## Upload with Notification
 
+The upload is silent by default — both recipient and sender mails are opt-in. Set `Recipients = true` to email each recipient with a download link, and/or `Sender = true` for a confirmation back to the sender.
+
 ```csharp
 var result = await sealed.UploadAsync(new UploadOptions
 {
     Notify = new NotifyOptions
     {
+        Recipients = true,            // email each recipient (default false)
+        Sender = false,               // confirmation to sender (default false)
         Message = "Your documents are ready.",
-        Language = "EN",              // "EN" (default) or "NL"
-        ConfirmToSender = false       // send copy to sender
+        Language = "EN"               // "EN" (default) or "NL"
     }
 });
 
 Console.WriteLine(result.Uuid);
 ```
+
+### Notify options
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `Recipients` | `bool` | `false` | Send a download-link email to each recipient |
+| `Sender` | `bool` | `false` | Send a delivery confirmation to the sender |
+| `Message` | `string?` | `null` | Optional unencrypted text included in any mail sent |
+| `Language` | `string` | `"EN"` | Notification email template language (`"EN"` or `"NL"`) |
 
 ## Recipients
 

--- a/docs/sdk/getting-started.md
+++ b/docs/sdk/getting-started.md
@@ -40,6 +40,8 @@ const sealed = pg.encrypt({
   sign: pg.sign.apiKey('PG-your-key'),
 });
 
+// Silent upload by default. Pass `notify: { recipients: true }` to have
+// Cryptify also email the recipient a download link.
 const { uuid } = await sealed.upload();
 ```
 
@@ -72,7 +74,7 @@ export default defineConfig({
 });
 ```
 
-<small>[Source: vite.config.ts](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/vite.config.ts)</small>
+<small>[Source: vite.config.ts](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/vite.config.ts)</small>
 
 No Node.js polyfills are needed. The SDK handles all browser compatibility internally.
 
@@ -113,6 +115,8 @@ var sealed = pg.Encrypt(new EncryptInput
     Sign = pg.Sign.ApiKey("PG-your-key")
 });
 
+// Silent upload by default. Pass `new UploadOptions { Notify = new
+// NotifyOptions { Recipients = true } }` to also email the recipient.
 var result = await sealed.UploadAsync();
 Console.WriteLine(result.Uuid);
 ```

--- a/docs/sdk/js-auth-methods.md
+++ b/docs/sdk/js-auth-methods.md
@@ -29,11 +29,15 @@ const sealed = pg.encrypt({
 });
 
 const result = await sealed.upload({
-  notify: { message: message ?? undefined, language: 'EN' }
+  notify: {
+    recipients: true,
+    message: message ?? undefined,
+    language: 'EN'
+  }
 });
 ```
 
-<small>[Source: encryption.ts#L26-L43](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts#L26-L43)</small>
+<small>[Source: encryption.ts#L24-L44](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts#L24-L44)</small>
 
 The SDK sends the API key as a `Bearer` token in the `Authorization` header when requesting signing keys from the PKG at `POST /v2/irma/sign/key`.
 

--- a/docs/sdk/js-encryption.md
+++ b/docs/sdk/js-encryption.md
@@ -7,8 +7,8 @@
 | Method | What it does | Returns |
 |--------|--------------|---------|
 | `sealed.toBytes()` | Encrypt and buffer in memory | `Promise<Uint8Array>` |
-| `sealed.upload()` | Encrypt and stream to Cryptify | `Promise<{ uuid }>` |
-| `sealed.upload({ notify })` | Same, plus Cryptify sends email | `Promise<{ uuid }>` |
+| `sealed.upload()` | Encrypt and stream to Cryptify (silent — no Cryptify-sent emails) | `Promise<{ uuid }>` |
+| `sealed.upload({ notify })` | Same, plus opt-in Cryptify-sent emails | `Promise<{ uuid }>` |
 
 ## Recipients
 
@@ -29,7 +29,7 @@ const sealed = pg.encrypt({
 });
 ```
 
-<small>[Source: encryption.ts#L26-L35](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts#L26-L35)</small>
+<small>[Source: encryption.ts#L27-L33](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts#L27-L33)</small>
 
 Under the hood, `pg.recipient.email()` creates a policy with the attribute type `pbdf.sidn-pbdf.email.email`, while `pg.recipient.emailDomain()` extracts the domain from the email and uses `pbdf.sidn-pbdf.email.domain`.
 
@@ -54,16 +54,23 @@ const sealed = pg.encrypt({
   signal: abortController?.signal
 });
 
-// Upload only (returns UUID for custom delivery)
+// Silent upload — no Cryptify-sent emails. Returns UUID for custom delivery.
 const { uuid } = await sealed.upload();
 
-// Upload and have Cryptify send email notifications
+// Or opt into Cryptify-sent emails. `recipients: true` emails each
+// recipient with a download link; `sender: true` adds a confirmation
+// back to the sender. Both default false.
 const { uuid } = await sealed.upload({
-  notify: { message: 'Here are your files', language: 'EN' }
+  notify: {
+    recipients: true,
+    sender: false,
+    message: 'Here are your files',
+    language: 'EN'
+  }
 });
 ```
 
-<small>[Source: encryption.ts#L22-L46](https://github.com/encryption4all/postguard-examples/blob/d6c7f01d3cb63d84e94b1e59079b0d80d748d23b/pg-sveltekit/src/lib/postguard/encryption.ts#L22-L46)</small>
+<small>[Source: encryption.ts#L24-L60](https://github.com/encryption4all/postguard-examples/blob/3d06342fad2c749ca4d043070d1ad9c831c7bfc1/pg-sveltekit/src/lib/postguard/encryption.ts#L24-L60)</small>
 
 ::: warning
 Requires `cryptifyUrl` to be set in the constructor.
@@ -84,11 +91,14 @@ Requires `cryptifyUrl` to be set in the constructor.
 
 ### Notify options
 
+The upload is silent by default — both recipient and sender mails are opt-in. Pass `notify` to enable either or both.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `message` | `string` | `undefined` | Custom message in the notification email |
-| `language` | `'EN' \| 'NL'` | `'EN'` | Language of the notification email |
-| `confirmToSender` | `boolean` | `false` | Send a delivery confirmation to the sender |
+| `recipients` | `boolean` | `false` | Send a download-link email to each recipient |
+| `sender` | `boolean` | `false` | Send a delivery confirmation to the sender |
+| `message` | `string` | `undefined` | Optional unencrypted text included in any mail sent |
+| `language` | `'EN' \| 'NL'` | `'EN'` | Notification email template language |
 
 ## Encrypt raw data
 


### PR DESCRIPTION
## Why

`@e4a/pg-js@1.2.0` and `E4A.PostGuard 0.3.0` (released as part of the silent-by-default upload-notification redesign — see encryption4all/postguard-js#41 and encryption4all/postguard-dotnet#6) ship a breaking API change that the docs didn't reflect:

- The upload is now silent by default — both per-recipient and sender mails are opt-in.
- `confirmToSender` / `ConfirmToSender` renamed to `sender` / `Sender` for symmetry with the new `recipients` / `Recipients` toggle.

Without this PR, every code sample in the docs is wrong.

## What

Updated 10 pages to the new shape, and repinned all source links to commits where the new code actually exists:

\`\`\`ts
sealed.upload({
  notify: {
    recipients: true,        // default false
    sender: false,           // default false (was confirmToSender)
    message: '...',          // unencrypted text on any mails sent
    language: 'EN',
  },
});
\`\`\`

Files touched:

- \`docs/index.md\`, \`docs/guide/concepts.md\` — homepage and concept snippets
- \`docs/repos/{postguard-js,postguard-dotnet,pg-sveltekit,pg-dotnet}.md\` — repo overview pages
- \`docs/sdk/{js,dotnet}-encryption.md\` — terminal-method and notify-option tables; also added a `recipients` row + reframed the silent-by-default behaviour
- \`docs/sdk/{js-auth-methods,getting-started}.md\` — supporting samples and a one-line note that the bare \`upload()\` is silent

All affected code snippets are now pinned to:

- \`postguard-examples@3d06342fad2c749ca4d043070d1ad9c831c7bfc1\` (PR #21 merged — same redesign in the example repo)
- \`postguard-js@2e2e0442a23b9f821a2bca008fe270af6c487e30\` (PR #41 merged, released as 1.2.0 on npm)

## Test plan

- [ ] `npm run docs:dev` and visually scan the affected pages.
- [ ] Click each `<small>[Source: …]</small>` link in the affected snippets — they should open the right line ranges on GitHub at the new commit.