### PR TITLE
chore(deps): bump @e4a/pg-js to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "vitepress-plugin-mermaid": "^2.0.17"
       },
       "devDependencies": {
-        "@e4a/pg-js": "^1.3.0",
+        "@e4a/pg-js": "^1.5.0",
         "vitepress": "^1.6.4"
       }
     },
@@ -407,17 +407,17 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.3.0.tgz",
-      "integrity": "sha512-0e31LLos0XmXlYZ/TqJb6j1RStzICEmyC8s9qjVgF1w3z4hnnevRq2c0/9XpsZseFi0Vwr6S7GqZoKtqvcd8HQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
+      "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-wasm": "^0.5.9",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+        "@e4a/pg-wasm": "^0.5.10",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
         "@transcend-io/conflux": "^6.1.3"
       }
     },
@@ -861,36 +861,36 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-1B0NryDau4rkv6w6Y2eLesoynuVvKNEKC/6MZPdPMDo8ecnN02bZM+gpogqO0Th94NKK+iXtRREqKWaopXJhIQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
+      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
       "dev": true,
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-xkwTLfVRnGW7RTLjPMvLYbnvYz/ULpZZnzKJwXP9zNdHup0Ol2JGN83dIvq979CtG2vdJUeh8hOoQfPsFaiqnQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
       "dev": true,
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.4.tgz",
-      "integrity": "sha512-ccV8Wb39gChj9t6nYugYrd5QVvsC9AmQhonsEkBVUX3JQavZVeowTX4Y+VBonJVDfPAvPLaqUdlnVhIDnRLPvA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
+      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
       "dev": true,
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.4.tgz",
-      "integrity": "sha512-+TMKX1NlHHAD3Lk8MFDcATzDK4muc/1zmyKD3Nwfk8WRb4p2RNNeqwCvztVmZ6V8OVGFFJOT2gMPRv/Z/e2egA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
+      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
       "dev": true,
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
@@ -898,7 +898,7 @@
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
-    "@e4a/pg-js": "^1.3.0",
+    "@e4a/pg-js": "^1.5.0",
     "vitepress": "^1.6.4"
   },
   "dependencies": {


### PR DESCRIPTION
DevDependency only — pg-js is listed for type info that the markdown code samples reference, not imported at runtime by VitePress. The bump itself is mechanical: install resolves cleanly to 1.5.0 and \`docs:build\` produces the same site.

Picks up [encryption4all/postguard-js#52](https://github.com/encryption4all/postguard-js/pull/52) (resumable downloads) and [#47](https://github.com/encryption4all/postguard-js/pull/47) (chunk PUT retry/backoff) so any future SDK type imports in \`.vitepress/\` pick up the latest shapes.

The code snippets under \`docs/sdk/\` and \`docs/repos/\` are pinned to specific commit hashes from the source repos per the project conventions in \`CLAUDE.md\`, so they update independently of this dep bump.

## Test plan

- [x] \`npm install\` — resolves to 1.5.0
- [x] \`npm run docs:build\` — site builds clean (the 500 kB chunk-size warning is pre-existing, mermaid-related, unrelated to pg-js)