### PR TITLE
chore: update Cryptify staging URL to storage.staging.postguard.eu

### DIFF
--- a/docs/repos/pg-dotnet.md
+++ b/docs/repos/pg-dotnet.md
@@ -54,7 +54,7 @@ dotnet run
 var pg = new PostGuard(new PostGuardConfig
 {
     PkgUrl = "https://pkg.staging.postguard.eu",
-    CryptifyUrl = "https://fileshare.staging.postguard.eu"
+    CryptifyUrl = "https://storage.staging.postguard.eu"
 });
 
 var sealed = pg.Encrypt(new EncryptInput

--- a/docs/repos/postguard-dotnet.md
+++ b/docs/repos/postguard-dotnet.md
@@ -15,7 +15,7 @@ using E4A.PostGuard.Models;
 var pg = new PostGuard(new PostGuardConfig
 {
     PkgUrl = "https://pkg.staging.postguard.eu",
-    CryptifyUrl = "https://fileshare.staging.postguard.eu"
+    CryptifyUrl = "https://storage.staging.postguard.eu"
 });
 // PkgUrl and CryptifyUrl must be absolute https:// URLs.
 // The constructor throws ArgumentException otherwise.

--- a/docs/sdk/dotnet-encryption.md
+++ b/docs/sdk/dotnet-encryption.md
@@ -11,7 +11,7 @@ using E4A.PostGuard.Models;
 var pg = new PostGuard(new PostGuardConfig
 {
     PkgUrl = "https://pkg.staging.postguard.eu",
-    CryptifyUrl = "https://fileshare.staging.postguard.eu",
+    CryptifyUrl = "https://storage.staging.postguard.eu",
     Headers = new Dictionary<string, string>     // optional
     {
         ["X-My-Client"] = "v1.0"

--- a/docs/sdk/getting-started.md
+++ b/docs/sdk/getting-started.md
@@ -105,7 +105,7 @@ using E4A.PostGuard.Models;
 var pg = new PostGuard(new PostGuardConfig
 {
     PkgUrl = "https://pkg.staging.postguard.eu",
-    CryptifyUrl = "https://fileshare.staging.postguard.eu"
+    CryptifyUrl = "https://storage.staging.postguard.eu"
 });
 
 var sealed = pg.Encrypt(new EncryptInput


### PR DESCRIPTION
## Summary
- The Cryptify staging deployment moved from `fileshare.staging.postguard.eu` to `storage.staging.postguard.eu`.
- Updates the four .NET-side snippets that hardcode the old hostname:
  - `docs/repos/pg-dotnet.md`
  - `docs/repos/postguard-dotnet.md`
  - `docs/sdk/dotnet-encryption.md`
  - `docs/sdk/getting-started.md`

## Out of scope
- JS-side snippets still reference `fileshare.staging.yivi.app` — different brand path, left for a separate review.
- `fileshare.postguard.eu` (production) is also untouched — only staging was renamed.

## Test plan
- [ ] Visual review of each updated snippet renders correctly under VitePress.
- [ ] No other files mention `fileshare.staging.postguard.eu` after this PR.

Companion PR in postguard-examples: encryption4all/postguard-examples#37

/dobby please review